### PR TITLE
Adjustements to RasterScanner

### DIFF
--- a/src/damagescanner/core.py
+++ b/src/damagescanner/core.py
@@ -57,7 +57,6 @@ def RasterScanner(landuse_map,
                   curve_path,
                   maxdam_path,
                   dtype = np.int32,
-                  centimeters=False,
                   save=False,
                   **kwargs):
     """
@@ -83,8 +82,8 @@ def RasterScanner(landuse_map,
         *dtype*: Set the dtype to the requires precision. This will affect the output damage raster as well 
      
     Optional Arguments:
-        *centimeters* : Set to True if the inundation map and curves are in 
-        centimeters
+        *nan_value* : if nan_value is provided, will mask the inundation file. 
+        This option can significantly fasten computations
         
         *save* : Set to True if you would like to save the output. Requires 
         several **kwargs**
@@ -172,15 +171,13 @@ def RasterScanner(landuse_map,
     
     if maxdam.shape[0] != (curves.shape[1]-1):
         raise ValueError("Dimensions between maximum damages and the number of depth-damage curve do not agree")
-
+  
     # Speed up calculation by only considering feasible points
-    if centimeters:
-        inundation[inundation > 1000] = 0
-    else:
-        inundation[inundation > 10] = 0
-        
-    inun = inundation * (inundation >= 0) + 0
-    inun[inun >= curves[:, 0].max()] = curves[:, 0].max()
+    if nan_value:
+        inundation[inundation == nan_value] = 0
+
+    inun = inundation * (inundation >= 0) + 0   
+    inun[inun >= curves[:, 0].max()] = curves[:, 0].max()   
     area = inun > 0
     waterdepth = inun[inun > 0]
     landuse = landuse[inun > 0]

--- a/src/damagescanner/core.py
+++ b/src/damagescanner/core.py
@@ -82,13 +82,13 @@ def RasterScanner(landuse_map,
         *dtype*: Set the dtype to the requires precision. This will affect the output damage raster as well 
      
     Optional Arguments:
-        *nan_value* : if nan_value is provided, will mask the inundation file. 
-        This option can significantly fasten computations
-        
         *save* : Set to True if you would like to save the output. Requires 
         several **kwargs**
         
     kwargs:
+        *nan_value* : if nan_value is provided, will mask the inundation file. 
+        This option can significantly fasten computations
+        
         *cell_size* : If both the landuse and inundation map are numpy arrays, 
         manually set the cell size.
         
@@ -173,7 +173,8 @@ def RasterScanner(landuse_map,
         raise ValueError("Dimensions between maximum damages and the number of depth-damage curve do not agree")
   
     # Speed up calculation by only considering feasible points
-    if nan_value:
+    if kwargs.get('nan_value'):
+        nan_value = kwargs.get('nan_value')
         inundation[inundation == nan_value] = 0
 
     inun = inundation * (inundation >= 0) + 0   
@@ -208,15 +209,8 @@ def RasterScanner(landuse_map,
                                     'losses']).groupby('landuse').sum()
 
     if save:
-        if src.crs:
-            crs = src.crs
-        else:
-            crs = kwargs.get('crs', crs)
-        
-        if src.crs:
-            transform = src.transform
-        else:
-            transform = kwargs.get('transform', transform)
+        crs = kwargs.get('crs', src.crs)
+        transform = kwargs.get('transform', transform)
 
         # requires adding output_path and scenario_name to function call
         # If output path is not defined, will place file in current directory


### PR DESCRIPTION
-In its previous form, the RasterScanner function was not running if for example all the arguments were provided as arrays. To circumvent this problem, I added some kwarg arguments. 
-Also added more description and some tests for the depth-damage curve data to make clear input has to be between 0 and 1, otherwise the function will run completely without returning errors or warnings. 
-Adjusted the read_csv() function to similar arguments to have the same behaviour when reading maxdam and curves_path
-Added a dtype argument to allow float values. 
