### PR TITLE
Missing comma in setup.py creates problem in my environment :)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
         'shapely>=1.6',
         'geopandas>=0.4.0',
-	'pandas>=0.23.4'
+	'pandas>=0.23.4',
 	'rasterio>=1.0.8',
 	'numpy>=1.15.2',
 	'matplotlib>=3.0.0',


### PR DESCRIPTION
Hey Elco, 

I couldn't properly install another package because of the missing comma between the description of the required package. I figured that others may have the same problem so created the pull request. 

Cheers, 

Anaïs