### PR TITLE
Fix/issue 65 object type column

### DIFF
--- a/src/damagescanner/core.py
+++ b/src/damagescanner/core.py
@@ -465,7 +465,7 @@ class DamageScanner(object):
             if self.assessment_type == "raster":
                 return largest_rp
             else:
-                return largest_rp[["osm_id", "object_type", "geometry", "risk"]]
+                return largest_rp[["osm_id", object_col, "geometry", "risk"]]
 
         else:
             # only keep the damage values
@@ -508,5 +508,5 @@ class DamageScanner(object):
 
             # return the risk in a concise dataframe
             return largest_rp[
-                ["osm_id", "object_type", "geometry"] + list(multi_curves.keys())
+                ["osm_id", object_col, "geometry"] + list(multi_curves.keys())
             ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -201,6 +201,22 @@ class TestRiskCalculation:
         # Result could be None if no damages, or a DataFrame
         assert result is None or isinstance(result, pd.DataFrame)
 
+    def test_risk_vector_columns_with_custom_object_col(
+        self, vector_inputs: dict, hazard_dict: dict
+    ) -> None:
+        """Test that custom object col is correctly used in risk calculation."""
+        ds = DamageScanner(
+            hazard_data=vector_inputs["hazard"],
+            feature_data=vector_inputs["exposure"],
+            curves=vector_inputs["curves"],
+            maxdam=vector_inputs["maxdam"],
+        )
+
+        result = ds.risk(hazard_dict, object_col="landuse")
+
+        assert isinstance(result, pd.DataFrame)
+        assert "object_type" not in result.columns
+        assert "landuse" in result.columns
 
 class TestOSMExposure:
     """Tests for OSM-based exposure analysis."""


### PR DESCRIPTION
Fixed a bug where the object_col variable of the `DamageScanner.risk` function (introduced in #55 as part of commit e2a12f7) was not used in all necessary places.

Bug is replicated in tests/test_core.TestRiskCalculation.test_risk_vector_columns_with_custom_object_col
(Technically, the behaviour is also in the multi-curve logic, but I was not able to figure out how to get a test working for that line)

Happy to drop the test from the PR if you don't feel like it is necessary :)